### PR TITLE
Fix drag and drop bug on non-Windows platforms

### DIFF
--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -194,9 +194,10 @@ class MainWindow(QMainWindow):
             event.ignore()
 
     def dragEnterEvent(self, event):
-        paths = str.splitlines(event.mimeData().text())
+        urls = event.mimeData().urls()
         has_wav = False
-        for path in paths:
+        for url in urls:
+            path = url.toLocalFile()
             ext = os.path.splitext(path)[1]
             if ext.lower() == '.wav':
                 has_wav = True
@@ -205,13 +206,14 @@ class MainWindow(QMainWindow):
             event.accept()
 
     def dropEvent(self, event):
-        paths = str.splitlines(event.mimeData().text())
-        for path in paths:
+        urls = event.mimeData().urls()
+        for url in urls:
+            path = url.toLocalFile()
             ext = os.path.splitext(path)[1]
             if ext.lower() != '.wav':
                 continue
             item = QListWidgetItem()
             item.setText(QFileInfo(path).fileName())
             item.setData(Qt.ItemDataRole.UserRole + 1,
-                         path.replace('file:///', ''))
+                         path)
             self.ui.listWidgetTaskList.addItem(item)


### PR DESCRIPTION
Currently, the drag and drop only works on Windows, not on macOS.

This is because file urls are different:
| Platform | Path | URL | `.replace('file:///', '')` |
| --- | --- | --- | --- |
| Windows | `D:/audio/sample.wav` | `file:///D:/audio/sample.wav` | `D:/audio/sample.wav` |
| macOS | `/Users/apple/sample.wav` | `file:///Users/apple/sample.wav` | `Users/apple/sample.wav` |

So, simply removing `file:///` is not portable across platforms.

A portable solution is to use [`urls()`](https://doc.qt.io/qtforpython-6/PySide6/QtCore/QMimeData.html#PySide6.QtCore.PySide6.QtCore.QMimeData.urls) method of [`QMimeData`](https://doc.qt.io/qtforpython-6/PySide6/QtCore/QMimeData.html) to get a list of file urls ([`QUrl`](https://doc.qt.io/qtforpython-6/PySide6/QtCore/QUrl.html)), iterate through the list and use [`toLocalFile()`](https://doc.qt.io/qtforpython-6/PySide6/QtCore/QUrl.html#PySide6.QtCore.PySide6.QtCore.QUrl.toLocalFile) method to convert the URL to path string.