### PR TITLE
Add support for more input types, add alternative output formats Closes #20

### DIFF
--- a/gui/Ui_MainWindow.py
+++ b/gui/Ui_MainWindow.py
@@ -254,7 +254,7 @@ class Ui_MainWindow(object):
         self.label_7.setText(QCoreApplication.translate("MainWindow", u"Output Directory (default to the same as the audio)", None))
         self.lineEditOutputDir.setText("")
         self.pushButtonBrowse.setText(QCoreApplication.translate("MainWindow", u"Browse...", None))
-        self.label.setText(QCoreApplication.translate("MainWindow", u"Output Type", None))
+        self.label.setText(QCoreApplication.translate("MainWindow", u"Output Format", None))
         self.radioButton.setText(QCoreApplication.translate("MainWindow", u"wav", None))
         self.radioButton_1.setText(QCoreApplication.translate("MainWindow", u"flac", None))
         self.radioButton_2.setText(QCoreApplication.translate("MainWindow", u"mp3", None))

--- a/gui/Ui_MainWindow.py
+++ b/gui/Ui_MainWindow.py
@@ -177,6 +177,7 @@ class Ui_MainWindow(object):
         self.buttonGroup.setObjectName(u"buttonGroup")
         self.buttonGroup.addButton(self.radioButton)
         self.radioButton.setObjectName(u"radioButton")
+        self.radioButton.setText(u"wav")
         self.radioButton.setChecked(True)
 
         self.horizontalLayout_5.addWidget(self.radioButton, 0, Qt.AlignHCenter)
@@ -184,6 +185,7 @@ class Ui_MainWindow(object):
         self.radioButton_1 = QRadioButton(self.groupBox_2)
         self.buttonGroup.addButton(self.radioButton_1)
         self.radioButton_1.setObjectName(u"radioButton_1")
+        self.radioButton_1.setText(u"flac")
 
         self.horizontalLayout_5.addWidget(self.radioButton_1, 0, Qt.AlignHCenter)
 
@@ -191,6 +193,7 @@ class Ui_MainWindow(object):
         self.buttonGroup.addButton(self.radioButton_2)
         self.radioButton_2.setObjectName(u"radioButton_2")
         self.radioButton_2.setEnabled(True)
+        self.radioButton_2.setText(u"mp3")
 
         self.horizontalLayout_5.addWidget(self.radioButton_2, 0, Qt.AlignHCenter)
 
@@ -255,9 +258,6 @@ class Ui_MainWindow(object):
         self.lineEditOutputDir.setText("")
         self.pushButtonBrowse.setText(QCoreApplication.translate("MainWindow", u"Browse...", None))
         self.label.setText(QCoreApplication.translate("MainWindow", u"Output Format", None))
-        self.radioButton.setText(QCoreApplication.translate("MainWindow", u"wav", None))
-        self.radioButton_1.setText(QCoreApplication.translate("MainWindow", u"flac", None))
-        self.radioButton_2.setText(QCoreApplication.translate("MainWindow", u"mp3", None))
         self.pushButtonAbout.setText(QCoreApplication.translate("MainWindow", u"About", None))
         self.pushButtonStart.setText(QCoreApplication.translate("MainWindow", u"Start", None))
     # retranslateUi

--- a/gui/Ui_MainWindow.py
+++ b/gui/Ui_MainWindow.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ui_mainwindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.4.0
+## Created by: Qt User Interface Compiler version 6.5.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -15,10 +15,11 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QApplication, QFormLayout, QFrame, QGroupBox,
-    QHBoxLayout, QLabel, QLineEdit, QListWidget,
-    QListWidgetItem, QMainWindow, QProgressBar, QPushButton,
-    QSizePolicy, QSpacerItem, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QApplication, QButtonGroup, QFormLayout, QFrame,
+    QGroupBox, QHBoxLayout, QLabel, QLineEdit,
+    QListWidget, QListWidgetItem, QMainWindow, QProgressBar,
+    QPushButton, QRadioButton, QSizePolicy, QSpacerItem,
+    QVBoxLayout, QWidget)
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
@@ -26,7 +27,7 @@ class Ui_MainWindow(object):
             MainWindow.setObjectName(u"MainWindow")
         MainWindow.resize(768, 480)
         font = QFont()
-        font.setFamily(u"Microsoft YaHei UI")
+        font.setFamilies([u"Microsoft YaHei UI"])
         MainWindow.setFont(font)
         self.centralwidget = QWidget(MainWindow)
         self.centralwidget.setObjectName(u"centralwidget")
@@ -164,6 +165,38 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_3.addLayout(self.horizontalLayout_4)
 
+        self.horizontalLayout_5 = QHBoxLayout()
+        self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
+        self.label = QLabel(self.groupBox_2)
+        self.label.setObjectName(u"label")
+
+        self.horizontalLayout_5.addWidget(self.label)
+
+        self.radioButton = QRadioButton(self.groupBox_2)
+        self.buttonGroup = QButtonGroup(MainWindow)
+        self.buttonGroup.setObjectName(u"buttonGroup")
+        self.buttonGroup.addButton(self.radioButton)
+        self.radioButton.setObjectName(u"radioButton")
+        self.radioButton.setChecked(True)
+
+        self.horizontalLayout_5.addWidget(self.radioButton, 0, Qt.AlignHCenter)
+
+        self.radioButton_1 = QRadioButton(self.groupBox_2)
+        self.buttonGroup.addButton(self.radioButton_1)
+        self.radioButton_1.setObjectName(u"radioButton_1")
+
+        self.horizontalLayout_5.addWidget(self.radioButton_1, 0, Qt.AlignHCenter)
+
+        self.radioButton_2 = QRadioButton(self.groupBox_2)
+        self.buttonGroup.addButton(self.radioButton_2)
+        self.radioButton_2.setObjectName(u"radioButton_2")
+        self.radioButton_2.setEnabled(True)
+
+        self.horizontalLayout_5.addWidget(self.radioButton_2, 0, Qt.AlignHCenter)
+
+
+        self.verticalLayout_3.addLayout(self.horizontalLayout_5)
+
         self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
         self.verticalLayout_3.addItem(self.verticalSpacer)
@@ -221,6 +254,11 @@ class Ui_MainWindow(object):
         self.label_7.setText(QCoreApplication.translate("MainWindow", u"Output Directory (default to the same as the audio)", None))
         self.lineEditOutputDir.setText("")
         self.pushButtonBrowse.setText(QCoreApplication.translate("MainWindow", u"Browse...", None))
+        self.label.setText(QCoreApplication.translate("MainWindow", u"Output Type", None))
+        self.radioButton.setText(QCoreApplication.translate("MainWindow", u"wav", None))
+        self.radioButton_1.setText(QCoreApplication.translate("MainWindow", u"flac", None))
+        self.radioButton_2.setText(QCoreApplication.translate("MainWindow", u"mp3", None))
         self.pushButtonAbout.setText(QCoreApplication.translate("MainWindow", u"About", None))
         self.pushButtonStart.setText(QCoreApplication.translate("MainWindow", u"Start", None))
     # retranslateUi
+

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -51,10 +51,11 @@ class MainWindow(QMainWindow):
         # Must set to accept drag and drop events
         self.setAcceptDrops(True)
 
-        # Get available formats
+        # Get available formats/extensions supported
         self.availableFormats = [str(formatExt).lower() for formatExt in soundfile.available_formats().keys()]
-        # hacky way to make to recognize .opus files, supported by libsndfile
-        # blame yt-dl(p) for using that ext and making me add this
+        # libsndfile supports Opus in Ogg container
+        # .opus is a valid extension and recommended for Ogg Opus (see RFC 7845, Section 9)
+        # append opus for convenience as tools like youtube-dl(p) extract to .opus by default
         self.availableFormats.append("opus")
 
         self.formatAllFilter = " ".join([f"*.{formatExt}" for formatExt in self.availableFormats])

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -51,6 +51,15 @@ class MainWindow(QMainWindow):
         # Must set to accept drag and drop events
         self.setAcceptDrops(True)
 
+        # Get available formats
+        self.availableFormats = [str(formatExt).lower() for formatExt in soundfile.available_formats().keys()]
+        # hacky way to make to recognize .opus files, supported by libsndfile
+        # blame yt-dl(p) for using that ext and making me add this
+        self.availableFormats.append("opus")
+
+        self.formatAllFilter = " ".join([f"*.{formatExt}" for formatExt in self.availableFormats])
+        self.formatIndividualFilter = ";;".join([f"{formatExt} (*.{formatExt})" for formatExt in sorted(self.availableFormats)])
+
     def _q_browse_output_dir(self):
         path = QFileDialog.getExistingDirectory(
             self, "Browse Output Directory", ".")
@@ -63,7 +72,7 @@ class MainWindow(QMainWindow):
             return
 
         paths, _ = QFileDialog.getOpenFileNames(
-            self, 'Select Audio Files', ".", 'Wave Files(*.wav)')
+            self, 'Select Audio Files', ".", f'Audio ({self.formatAllFilter});;{self.formatIndividualFilter}')
         for path in paths:
             item = QListWidgetItem()
             item.setSizeHint(QSize(200, 24))
@@ -127,8 +136,9 @@ class MainWindow(QMainWindow):
                         if not info.exists():
                             info.mkpath(out_dir)
 
+                    ext = self.win.ui.buttonGroup.checkedButton().text()
                     for i, chunk in enumerate(chunks):
-                        path = os.path.join(out_dir, f'%s_%d.wav' % (os.path.basename(filename)
+                        path = os.path.join(out_dir, f'%s_%d.{ext}' % (os.path.basename(filename)
                                                                      .rsplit('.', maxsplit=1)[0], i))
                         if not is_mono:
                             chunk = chunk.T
@@ -201,16 +211,16 @@ class MainWindow(QMainWindow):
 
     def dragEnterEvent(self, event):
         urls = event.mimeData().urls()
-        has_wav = False
+        valid = False
         for url in urls:
             if not url.isLocalFile():
                 continue
             path = url.toLocalFile()
             ext = os.path.splitext(path)[1]
-            if ext.lower() == '.wav':
-                has_wav = True
+            if ext[1:].lower() in self.availableFormats:
+                valid = True
                 break
-        if has_wav:
+        if valid:
             event.accept()
 
     def dropEvent(self, event):
@@ -220,7 +230,7 @@ class MainWindow(QMainWindow):
                 continue
             path = url.toLocalFile()
             ext = os.path.splitext(path)[1]
-            if ext.lower() != '.wav':
+            if ext[1:].lower() not in self.availableFormats:
                 continue
             item = QListWidgetItem()
             item.setSizeHint(QSize(200, 24))

--- a/gui/ui_mainwindow.ui
+++ b/gui/ui_mainwindow.ui
@@ -225,7 +225,7 @@
            <item alignment="Qt::AlignHCenter">
             <widget class="QRadioButton" name="radioButton">
              <property name="text">
-              <string>wav</string>
+              <string notr="true">wav</string>
              </property>
              <property name="checked">
               <bool>true</bool>
@@ -238,7 +238,7 @@
            <item alignment="Qt::AlignHCenter">
             <widget class="QRadioButton" name="radioButton_1">
              <property name="text">
-              <string>flac</string>
+              <string notr="true">flac</string>
              </property>
              <attribute name="buttonGroup">
               <string notr="true">buttonGroup</string>
@@ -251,7 +251,7 @@
               <bool>true</bool>
              </property>
              <property name="text">
-              <string>mp3</string>
+              <string notr="true">mp3</string>
              </property>
              <attribute name="buttonGroup">
               <string notr="true">buttonGroup</string>

--- a/gui/ui_mainwindow.ui
+++ b/gui/ui_mainwindow.ui
@@ -218,7 +218,7 @@
            <item>
             <widget class="QLabel" name="label">
              <property name="text">
-              <string>Output Type</string>
+              <string>Output Format</string>
              </property>
             </widget>
            </item>

--- a/gui/ui_mainwindow.ui
+++ b/gui/ui_mainwindow.ui
@@ -214,6 +214,53 @@
           </layout>
          </item>
          <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Output Type</string>
+             </property>
+            </widget>
+           </item>
+           <item alignment="Qt::AlignHCenter">
+            <widget class="QRadioButton" name="radioButton">
+             <property name="text">
+              <string>wav</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">buttonGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item alignment="Qt::AlignHCenter">
+            <widget class="QRadioButton" name="radioButton_1">
+             <property name="text">
+              <string>flac</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">buttonGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item alignment="Qt::AlignHCenter">
+            <widget class="QRadioButton" name="radioButton_2">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>mp3</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">buttonGroup</string>
+             </attribute>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
           <spacer name="verticalSpacer">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -261,4 +308,7 @@
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
Implemented input support for all file formats supported by the user's `libsndfile`. This means `.mp3`, `flac`, and various other formats can now be input and split.

Also added three buttons to the GUI that gives user choice in what output format they want. `wav`, `flac`, `mp3`. Defaults to `wav`. Using `flac` and `mp3` results in a slightly slower output due to compression, but it saves a lot in file size. I can remove this feature if it's unwanted.

Threw this together quickly today. Based off simple testing this doesn't seem to break any functionality. Just noticed #20 so I guess this closes that. Only changes the GUI, though I'm sure these could be backported to the CLI. 