### PR TITLE
Reduce peak memory usage when slicing large audio files

### DIFF
--- a/gui/slicing_tasks.py
+++ b/gui/slicing_tasks.py
@@ -89,30 +89,14 @@ def run_slicing_task(
     written_paths: list[str] = []
 
     try:
-        audio, sample_rate = soundfile.read(source_path, dtype=np.float32)
-        is_mono = True
-        if len(audio.shape) > 1:
-            is_mono = False
-            audio = audio.T
-
-        slicer = Slicer(
-            sr=sample_rate,
-            threshold=settings.threshold,
-            min_length=settings.min_length,
-            min_interval=settings.min_interval,
-            hop_size=settings.hop_size,
-            max_sil_kept=settings.max_sil_kept,
-        )
-        chunks = slicer.slice(audio)
-
         target_dir = output_dir or os.path.dirname(os.path.abspath(source_path))
         os.makedirs(target_dir, exist_ok=True)
+        ranges, sample_rate, channels = analyze_slicing_task(source_path, settings)
 
         base_name = os.path.basename(source_path).rsplit(".", maxsplit=1)[0]
-        for index, chunk in enumerate(chunks):
-            chunk_to_write = chunk.T if not is_mono else chunk
+        for index, (begin, end) in enumerate(ranges):
             output_path = os.path.join(target_dir, f"{base_name}_{index}.{output_format}")
-            soundfile.write(output_path, chunk_to_write, sample_rate)
+            write_slice_range(source_path, output_path, sample_rate, channels, begin, end)
             written_paths.append(output_path)
     except Exception as exc:
         message = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
@@ -130,6 +114,85 @@ def run_slicing_task(
     )
 
 
+def analyze_slicing_task(
+    source_path: str,
+    settings: SlicingSettings,
+) -> tuple[list[tuple[int, int]], int, int]:
+    with soundfile.SoundFile(source_path) as source_file:
+        sample_rate = source_file.samplerate
+        channels = source_file.channels
+        total_samples = len(source_file)
+
+        slicer = Slicer(
+            sr=sample_rate,
+            threshold=settings.threshold,
+            min_length=settings.min_length,
+            min_interval=settings.min_interval,
+            hop_size=settings.hop_size,
+            max_sil_kept=settings.max_sil_kept,
+        )
+
+        if (total_samples + slicer.hop_size - 1) // slicer.hop_size <= slicer.min_length:
+            return [(0, total_samples)], sample_rate, channels
+
+        rms_list = build_rms_list_from_file(source_file, slicer)
+        ranges = slicer.slice_ranges_from_rms(rms_list, total_samples)
+        return ranges, sample_rate, channels
+
+
+def build_rms_list_from_file(
+    source_file: soundfile.SoundFile,
+    slicer: Slicer,
+    read_size: int = 131072,
+) -> np.ndarray:
+    source_file.seek(0)
+    pad = slicer.win_size // 2
+    buffer = np.zeros(pad, dtype=np.float32)
+    rms_parts: list[np.ndarray] = []
+
+    while True:
+        chunk = source_file.read(read_size, dtype="float32", always_2d=True)
+        if len(chunk) == 0:
+            break
+        mono = chunk.mean(axis=1, dtype=np.float32)
+        buffer = np.concatenate((buffer, mono.astype(np.float32, copy=False)))
+        values, buffer = _consume_rms_frames(buffer, slicer)
+        if values.size:
+            rms_parts.append(values)
+
+    buffer = np.concatenate((buffer, np.zeros(pad, dtype=np.float32)))
+    values, _ = _consume_rms_frames(buffer, slicer)
+    if values.size:
+        rms_parts.append(values)
+
+    if not rms_parts:
+        return np.zeros(0, dtype=np.float32)
+    return np.concatenate(rms_parts)
+
+
+def write_slice_range(
+    source_path: str,
+    output_path: str,
+    sample_rate: int,
+    channels: int,
+    begin: int,
+    end: int,
+    chunk_size: int = 65536,
+) -> None:
+    frames_remaining = max(0, end - begin)
+    with (
+        soundfile.SoundFile(source_path) as source_file,
+        soundfile.SoundFile(output_path, mode="w", samplerate=sample_rate, channels=channels) as output_file,
+    ):
+        source_file.seek(begin)
+        while frames_remaining > 0:
+            block = source_file.read(min(chunk_size, frames_remaining), dtype="float32", always_2d=True)
+            if len(block) == 0:
+                break
+            output_file.write(block)
+            frames_remaining -= len(block)
+
+
 def _parse_float(value: str, field_name: str) -> tuple[float | None, str]:
     try:
         return float(value), ""
@@ -142,3 +205,15 @@ def _parse_int(value: str, field_name: str) -> tuple[int | None, str]:
         return int(value), ""
     except ValueError:
         return None, f"{field_name} must be an integer."
+
+
+def _consume_rms_frames(buffer: np.ndarray, slicer: Slicer) -> tuple[np.ndarray, np.ndarray]:
+    if buffer.shape[0] < slicer.win_size:
+        return np.zeros(0, dtype=np.float32), buffer
+
+    usable = ((buffer.shape[0] - slicer.win_size) // slicer.hop_size) + 1
+    window_view = np.lib.stride_tricks.sliding_window_view(buffer, slicer.win_size)
+    windows = window_view[::slicer.hop_size][:usable]
+    rms_values = np.sqrt(np.mean(np.abs(windows) ** 2, axis=1, dtype=np.float64)).astype(np.float32)
+    remaining = buffer[usable * slicer.hop_size:]
+    return rms_values, remaining

--- a/gui/slicing_tasks.py
+++ b/gui/slicing_tasks.py
@@ -147,6 +147,7 @@ def build_rms_list_from_file(
 ) -> np.ndarray:
     source_file.seek(0)
     pad = slicer.win_size // 2
+    # Match get_rms(..., pad_mode="constant") by zero-padding half a window at both ends.
     buffer = np.zeros(pad, dtype=np.float32)
     rms_parts: list[np.ndarray] = []
 

--- a/slicer2.py
+++ b/slicer2.py
@@ -68,15 +68,34 @@ class Slicer:
         else:
             return waveform[begin * self.hop_size: min(waveform.shape[0], end * self.hop_size)]
 
-    # @timeit
-    def slice(self, waveform):
+    def _frame_to_sample(self, frame_index: int, total_samples: int) -> int:
+        return min(total_samples, frame_index * self.hop_size)
+
+    def slice_ranges(self, waveform):
         if len(waveform.shape) > 1:
             samples = waveform.mean(axis=0)
+            total_samples = waveform.shape[1]
         else:
             samples = waveform
+            total_samples = waveform.shape[0]
         if (samples.shape[0] + self.hop_size - 1) // self.hop_size <= self.min_length:
-            return [waveform]
-        rms_list = get_rms(y=samples, frame_length=self.win_size, hop_length=self.hop_size).squeeze(0)
+            return [(0, total_samples)]
+
+        rms_list = get_rms(
+            y=samples,
+            frame_length=self.win_size,
+            hop_length=self.hop_size,
+        ).squeeze(0)
+        return self.slice_ranges_from_rms(rms_list, total_samples)
+
+    def slice_ranges_from_rms(self, rms_list, total_samples):
+        if rms_list.shape[0] == 0:
+            return [(0, total_samples)]
+
+        total_frames = rms_list.shape[0]
+        if total_frames <= self.min_length:
+            return [(0, total_samples)]
+
         sil_tags = []
         silence_start = None
         clip_start = 0
@@ -125,23 +144,35 @@ class Slicer:
                 clip_start = pos_r
             silence_start = None
         # Deal with trailing silence.
-        total_frames = rms_list.shape[0]
         if silence_start is not None and total_frames - silence_start >= self.min_interval:
             silence_end = min(total_frames, silence_start + self.max_sil_kept)
             pos = rms_list[silence_start: silence_end + 1].argmin() + silence_start
             sil_tags.append((pos, total_frames + 1))
-        # Apply and return slices.
+
+        # Convert silent tags to sample ranges for the kept clips.
         if len(sil_tags) == 0:
-            return [waveform]
-        else:
-            chunks = []
-            if sil_tags[0][0] > 0:
-                chunks.append(self._apply_slice(waveform, 0, sil_tags[0][0]))
-            for i in range(len(sil_tags) - 1):
-                chunks.append(self._apply_slice(waveform, sil_tags[i][1], sil_tags[i + 1][0]))
-            if sil_tags[-1][1] < total_frames:
-                chunks.append(self._apply_slice(waveform, sil_tags[-1][1], total_frames))
-            return chunks
+            return [(0, total_samples)]
+
+        ranges = []
+        if sil_tags[0][0] > 0:
+            ranges.append((0, self._frame_to_sample(sil_tags[0][0], total_samples)))
+        for i in range(len(sil_tags) - 1):
+            ranges.append(
+                (
+                    self._frame_to_sample(sil_tags[i][1], total_samples),
+                    self._frame_to_sample(sil_tags[i + 1][0], total_samples),
+                )
+            )
+        if sil_tags[-1][1] < total_frames:
+            ranges.append((self._frame_to_sample(sil_tags[-1][1], total_samples), total_samples))
+        return ranges
+
+    # @timeit
+    def slice(self, waveform):
+        ranges = self.slice_ranges(waveform)
+        if len(waveform.shape) > 1:
+            return [waveform[:, begin:end] for begin, end in ranges]
+        return [waveform[begin:end] for begin, end in ranges]
 
 
 def main():

--- a/tests/test_slicer2.py
+++ b/tests/test_slicer2.py
@@ -1,0 +1,37 @@
+import math
+import unittest
+
+import numpy as np
+
+from slicer2 import Slicer
+
+
+class SliceRangesTests(unittest.TestCase):
+    def test_slice_ranges_match_slice_output(self):
+        sample_rate = 16000
+        tone = np.array(
+            [0.25 * math.sin(2 * math.pi * 440 * i / sample_rate) for i in range(sample_rate)],
+            dtype=np.float32,
+        )
+        silence = np.zeros(sample_rate // 2, dtype=np.float32)
+        waveform = np.concatenate([tone, silence, tone, silence, tone])
+        slicer = Slicer(
+            sr=sample_rate,
+            threshold=-40.0,
+            min_length=500,
+            min_interval=300,
+            hop_size=10,
+            max_sil_kept=100,
+        )
+
+        ranges = slicer.slice_ranges(waveform)
+        chunks = slicer.slice(waveform)
+
+        self.assertEqual(len(ranges), len(chunks))
+        rebuilt = [waveform[start:end] for start, end in ranges]
+        for rebuilt_chunk, chunk in zip(rebuilt, chunks):
+            self.assertTrue(np.allclose(rebuilt_chunk, chunk))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_slicing_tasks.py
+++ b/tests/test_slicing_tasks.py
@@ -7,7 +7,8 @@ from unittest import mock
 import numpy as np
 import soundfile
 
-from gui.slicing_tasks import SlicingSettings, parse_slicing_settings, run_slicing_task
+from gui.slicing_tasks import SlicingSettings, build_rms_list_from_file, parse_slicing_settings, run_slicing_task
+from slicer2 import Slicer, get_rms
 
 
 class RunSlicingTaskTests(unittest.TestCase):
@@ -50,7 +51,7 @@ class RunSlicingTaskTests(unittest.TestCase):
             self.assertTrue(Path(path).exists())
 
     def test_run_slicing_task_returns_failure_when_write_raises(self):
-        with mock.patch("gui.slicing_tasks.soundfile.write", side_effect=RuntimeError("disk full")):
+        with mock.patch("gui.slicing_tasks.write_slice_range", side_effect=RuntimeError("disk full")):
             result = run_slicing_task(
                 str(self.source_path),
                 str(self.output_dir),
@@ -61,6 +62,18 @@ class RunSlicingTaskTests(unittest.TestCase):
         self.assertFalse(result.success)
         self.assertEqual(result.output_count, 0)
         self.assertIn("disk full", result.error)
+
+    def test_run_slicing_task_streams_without_soundfile_read(self):
+        with mock.patch("gui.slicing_tasks.soundfile.read", side_effect=AssertionError("whole-file read should not be used")):
+            result = run_slicing_task(
+                str(self.source_path),
+                str(self.output_dir),
+                "wav",
+                self.settings,
+            )
+
+        self.assertTrue(result.success)
+        self.assertGreaterEqual(result.output_count, 1)
 
 
 class ParseSlicingSettingsTests(unittest.TestCase):
@@ -98,6 +111,39 @@ class ParseSlicingSettingsTests(unittest.TestCase):
                 max_sil_kept=100,
             ),
         )
+
+
+class BuildRmsListFromFileTests(unittest.TestCase):
+    def test_build_rms_list_from_file_matches_existing_rms_calculation(self):
+        sample_rate = 16000
+        tone = np.array(
+            [0.25 * math.sin(2 * math.pi * 440 * i / sample_rate) for i in range(sample_rate)],
+            dtype=np.float32,
+        )
+        silence = np.zeros(sample_rate // 2, dtype=np.float32)
+        waveform = np.concatenate([tone, silence, tone])
+        slicer = Slicer(
+            sr=sample_rate,
+            threshold=-40.0,
+            min_length=500,
+            min_interval=300,
+            hop_size=10,
+            max_sil_kept=100,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = Path(temp_dir) / "rms.wav"
+            soundfile.write(source_path, waveform, sample_rate)
+
+            with soundfile.SoundFile(source_path) as audio_file:
+                rms_list = build_rms_list_from_file(audio_file, slicer)
+
+        expected = get_rms(
+            y=waveform,
+            frame_length=slicer.win_size,
+            hop_length=slicer.hop_size,
+        ).squeeze(0)
+        self.assertTrue(np.allclose(rms_list, expected, atol=2e-6))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR reduces peak memory usage when slicing large audio files in the GUI path.

## Changes

- separate slice-boundary calculation from slice writing
- add range-based slicing support in `slicer2.py` while keeping `slice()` compatibility
- change GUI slicing tasks to analyze first and then write slice ranges incrementally
- avoid whole-file read + retained chunk arrays during GUI slicing
- add `unittest` coverage for range-based slicing and streamed RMS analysis

## Tests

```bash
python -m unittest tests.test_slicing_tasks tests.test_slicer2 tests.test_mainwindow tests.test_startup
```
